### PR TITLE
Update of Eurostreaming and Streamingcommunity Plugin URLs

### DIFF
--- a/EurostreamingProvider/src/main/kotlin/com/lagradost/EurostreamingProvider.kt
+++ b/EurostreamingProvider/src/main/kotlin/com/lagradost/EurostreamingProvider.kt
@@ -9,7 +9,7 @@ import com.lagradost.cloudstream3.utils.AppUtils.toJson
 
 class EurostreamingProvider : MainAPI() {
     override var lang = "it"
-    override var mainUrl = "https://eurostreaming.social"
+    override var mainUrl = "https://eurostreaming.boats"
     override var name = "Eurostreaming"
     override val hasMainPage = true
     override val hasChromecastSupport = true

--- a/StreamingcommunityProvider/src/main/kotlin/com/lagradost/StreamingcommunityProvider.kt
+++ b/StreamingcommunityProvider/src/main/kotlin/com/lagradost/StreamingcommunityProvider.kt
@@ -128,7 +128,7 @@ data class TrailerElement(
 
 class StreamingcommunityProvider: MainAPI() {
     override var lang = "it"
-    override var mainUrl = "https://streamingcommunity.golf"
+    override var mainUrl = "https://streamingcommunity.city"
     override var name = "StreamingCommunity"
     override val hasMainPage = true
     override val hasChromecastSupport = true


### PR DESCRIPTION
The website https://eurostreaming.social is not the official one.
The website https://streamingcommunity.golf has been no longer available for weeks.