### PR TITLE
Fix CineBlogProvider No links found

### DIFF
--- a/CineBlogProvider/src/main/kotlin/com/lagradost/CineBlogProvider.kt
+++ b/CineBlogProvider/src/main/kotlin/com/lagradost/CineBlogProvider.kt
@@ -160,7 +160,7 @@ class CineBlogProvider : MainAPI() {
         ))
 
         val url2= Regex("""src='((.|\\n)*?)'""").find(test.text)?.groups?.get(1)?.value.toString()
-        val trueUrl = app.get(url2, headers = mapOf("referer" to mainUrl)).url
+        val trueUrl = app.get(url2, headers = mapOf("Referer" to mainUrl)).url
         loadExtractor(trueUrl, data, subtitleCallback, callback)
 
         return true


### PR DESCRIPTION
referer is written in lower case, the first letter need to be uppercase otherwise the site will see this as another headers