### PR TITLE
fixes mainUrl for EntrePeliculasyseriesProvider

### DIFF
--- a/EntrepeliculasyseriesProvider/src/main/kotlin/com/lagradost/EntrepeliculasyseriesProvider.kt
+++ b/EntrepeliculasyseriesProvider/src/main/kotlin/com/lagradost/EntrepeliculasyseriesProvider.kt
@@ -5,7 +5,7 @@ import com.lagradost.cloudstream3.utils.ExtractorLink
 import com.lagradost.cloudstream3.utils.loadExtractor
 
 class EntrepeliculasyseriesProvider : MainAPI() {
-    override var mainUrl = "https://entrepeliculasyseries.nu"
+    override var mainUrl = "https://entrepeliculasyseries.nz"
     override var name = "EntrePeliculasySeries"
     override var lang = "es"
     override val hasMainPage = true


### PR DESCRIPTION
this provider has changed it's domain name I think updating the url can fix it.